### PR TITLE
Verify library binaries

### DIFF
--- a/jitpack.yml.template
+++ b/jitpack.yml.template
@@ -1,15 +1,8 @@
 before_install:
-  - mkdir -p LipaLightningLib/src/main/jniLibs/arm64
-  - mkdir -p LipaLightningLib/src/main/jniLibs/arm64-v8a
-  - mkdir -p LipaLightningLib/src/main/jniLibs/armeabi
-  - mkdir -p LipaLightningLib/src/main/jniLibs/x86
-  - wget https://github.com/getlipa/lipa-lightning-lib-android/releases/download/to_replace_release_version/libuniffi_lipalightninglib_arm64.so
-  - wget https://github.com/getlipa/lipa-lightning-lib-android/releases/download/to_replace_release_version/libuniffi_lipalightninglib_armeabi.so
-  - wget https://github.com/getlipa/lipa-lightning-lib-android/releases/download/to_replace_release_version/libuniffi_lipalightninglib_x86.so
-  - cp libuniffi_lipalightninglib_arm64.so LipaLightningLib/src/main/jniLibs/arm64/libuniffi_lipalightninglib.so
-  - cp libuniffi_lipalightninglib_arm64.so LipaLightningLib/src/main/jniLibs/arm64-v8a/libuniffi_lipalightninglib.so
-  - cp libuniffi_lipalightninglib_armeabi.so LipaLightningLib/src/main/jniLibs/armeabi/libuniffi_lipalightninglib.so
-  - cp libuniffi_lipalightninglib_x86.so LipaLightningLib/src/main/jniLibs/x86/libuniffi_lipalightninglib.so
+  - wget https://github.com/getlipa/lipa-lightning-lib-android/releases/download/to_replace_release_version/jniLibs.zip
+  - if [ $(shasum -a 256 jniLibs.zip | sed 's/ .*//') != 'to_replace_zip_checksum' ]; then exit 1; fi
+  - unzip -o jniLibs.zip
+  - mv jniLibs LipaLightningLib/src/main/jniLibs
   - wget https://github.com/java-native-access/jna/archive/refs/tags/5.8.0.zip
   - unzip 5.8.0.zip
   - unzip -o jna-5.8.0/dist/android-aarch64.jar


### PR DESCRIPTION
Fail the JitPack build if the binaries downloaded from the releases page don't have the expected sha256 hash.